### PR TITLE
sprockets-rails 3.x support

### DIFF
--- a/lib/autoprefixer-rails/railtie.rb
+++ b/lib/autoprefixer-rails/railtie.rb
@@ -7,16 +7,16 @@ begin
     class Railtie < ::Rails::Railtie
       rake_tasks do |app|
         require 'rake/autoprefixer_tasks'
-        Rake::AutoprefixerTasks.new( config(app)[0] )
+        Rake::AutoprefixerTasks.new( config(app.root)[0] )
       end
 
-      initializer :setup_autoprefixer, group: :all do |app|
-        AutoprefixerRails.install(app.assets, *config(app))
+      config.assets.configure do |env|
+        AutoprefixerRails.install(env, *config(env.root))
       end
 
       # Read browsers requirements from application config
-      def config(app)
-        file   = app.root.join('config/autoprefixer.yml')
+      def config(root)
+        file   = File.join(root, 'config/autoprefixer.yml')
         params = file.exist? ? ::YAML.load_file(file).symbolize_keys : { }
 
         opts   = { }

--- a/lib/autoprefixer-rails/railtie.rb
+++ b/lib/autoprefixer-rails/railtie.rb
@@ -10,8 +10,14 @@ begin
         Rake::AutoprefixerTasks.new( config(app.root)[0] )
       end
 
-      config.assets.configure do |env|
-        AutoprefixerRails.install(env, *config(env.root))
+      if config.respond_to?(:assets)
+        config.assets.configure do |env|
+          AutoprefixerRails.install(env, *config(env.root))
+        end
+      else
+        initializer :setup_autoprefixer, group: :all do |app|
+          AutoprefixerRails.install(app.assets, *config(app.root))
+        end
       end
 
       # Read browsers requirements from application config

--- a/lib/autoprefixer-rails/railtie.rb
+++ b/lib/autoprefixer-rails/railtie.rb
@@ -17,7 +17,7 @@ begin
       # Read browsers requirements from application config
       def config(root)
         file   = File.join(root, 'config/autoprefixer.yml')
-        params = file.exist? ? ::YAML.load_file(file).symbolize_keys : { }
+        params = File.exist?(file) ? ::YAML.load_file(file).symbolize_keys : { }
 
         opts   = { }
         opts[:safe] = true if params.delete(:safe)


### PR DESCRIPTION
This mostly future proofs autoprefixer-rails for Rails 5 + sprockets-rails 3. Neither are released yet.

Instead of using a railtie initializer hook, this installs a `config.assets.configure` block which is always guaranteed to run after the sprockets environment is created. The `config.assets.configure`  has always existed, so it should be backwards compatible.

Closes #52.

Though, this actually has nothing to do with Sprockets 3.x changes themself. autoprefixer-rails will likely want to make future apis changes for sprockets 3.x/4.x when it is released to work correctly with source map pass through. I can help you guys out with that when it is finally released.