### PR TITLE
Fix NoMethodError when config file is empty

### DIFF
--- a/lib/autoprefixer-rails/railtie.rb
+++ b/lib/autoprefixer-rails/railtie.rb
@@ -23,7 +23,9 @@ begin
       # Read browsers requirements from application config
       def config(root)
         file   = File.join(root, 'config/autoprefixer.yml')
-        params = File.exist?(file) ? ::YAML.load_file(file).symbolize_keys : { }
+        params = ::YAML.load_file(file) if File.exist?(file)
+        params ||= {}
+        params = params.symbolize_keys
 
         opts   = { }
         opts[:safe] = true if params.delete(:safe)


### PR DESCRIPTION
If the config file, autoprefixer.yml, is empty, then the config method in the
Railtie class will throw a NoMethodError as it calls symbolize_keys on
FalseClass when the YAML.load_file call fails.

The problem is fixed by making sure that symbolize_keys is called on a
hash.