### PR TITLE
use ExecJS::Context#call in-lieu of #eval for better support with alaska runtime

### DIFF
--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -19,9 +19,13 @@ module AutoprefixerRails
     def process(css, opts = {})
       opts = convert_options(opts)
 
-      result = runtime.exec(
-        "processor = autoprefixer(#{ js_params(opts[:from]) });" +
-        "return eval(process.apply(this, #{::JSON.generate([css,opts])}));")
+      apply_wrapper =
+        "(function(opts) {" +
+        "processor = autoprefixer(" + js_params(opts[:from]) + ");" +
+        "return eval(process.apply(this, opts));" +
+        "})"
+
+      result = runtime.call(apply_wrapper, [css, opts])
 
       Result.new(result['css'], result['map'])
     end


### PR DESCRIPTION
To provide better support for our expirmental `execjs` runtime 'Alaska': https://github.com/mavenlink/alaska

This is required because we do less overall wrapping of the code in `eval()` calls to achieve higher levels of performance. And the `alaska` runtime uses the nodejs `vm` module to create a sandbox context, which does not allow a naked return statement.

See this pull request for a similar issue found in the `uglifier` gem: https://github.com/lautis/uglifier/pull/80