### PR TITLE
Pass self to register_postprocessor instead of a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ You can get what properties will be changed using a Rake task:
 rake autoprefixer:info
 ```
 
-To disable Autoprefixer just remove postprocessor:
+To disable Autoprefixer just remove the postprocessor:
 
 ```ruby
-Rails.application.assets.unregister_postprocessor('text/css', :autoprefixer)
+Rails.application.assets.unregister_postprocessor('text/css', ::AutoprefixerRails::Sprockets)
 ```
 
 [Browserslist docs]: https://github.com/ai/browserslist

--- a/lib/autoprefixer-rails.rb
+++ b/lib/autoprefixer-rails.rb
@@ -15,7 +15,8 @@ module AutoprefixerRails
   # Add Autoprefixer for Sprockets environment in `assets`.
   # You can specify `browsers` actual in your project.
   def self.install(assets, params = { })
-    Sprockets.new( processor(params) ).install(assets)
+    ::AutoprefixerRails::Sprockets.processor = processor(params)
+    assets.register_postprocessor('text/css', ::AutoprefixerRails::Sprockets)
   end
 
   # Cache processor instances

--- a/lib/autoprefixer-rails/sprockets.rb
+++ b/lib/autoprefixer-rails/sprockets.rb
@@ -1,30 +1,23 @@
 require 'pathname'
 
 module AutoprefixerRails
-  # Register autoprefixer postprocessor in Sprockets and fix common issues
-  class Sprockets
-    def initialize(processor)
+  # Autoprefixer Sprockets postprocessor
+  module Sprockets
+    module_function
+
+    def processor=(processor)
       @processor = processor
     end
 
     # Add prefixes for `css`
-    def process(context, css)
-      input  = context.pathname.to_s
-      output = input.chomp(File.extname(input)) + '.css'
-      result = @processor.process(css, from: input, to: output)
+    def call(input)
+      result = @processor.process(input[:data], from: input[:filename])
 
       result.warnings.each do |warning|
         $stderr.puts "autoprefixer: #{ warning }"
       end
 
       result.css
-    end
-
-    # Register postprocessor in Sprockets depend on issues with other gems
-    def install(assets)
-      assets.register_postprocessor('text/css', :autoprefixer) do |context, css|
-        process(context, css)
-      end
     end
   end
 end


### PR DESCRIPTION
This enables support for Sprockets head where the block form doesn't work. See https://github.com/rails/sprockets/issues/138.