### PR TITLE
Don't assume that all Rails apps are using the asset pipeline.

### DIFF
--- a/lib/autoprefixer-rails.rb
+++ b/lib/autoprefixer-rails.rb
@@ -28,4 +28,4 @@ require_relative 'autoprefixer-rails/result'
 require_relative 'autoprefixer-rails/version'
 require_relative 'autoprefixer-rails/processor'
 
-require_relative 'autoprefixer-rails/railtie' if defined?(Rails)
+require_relative 'autoprefixer-rails/railtie' if defined?(Rails.application.assets)


### PR DESCRIPTION
This change allows autoprefixer-rails to work in Rails
environments that aren't using the asset pipeline.