### PR TITLE
register a sprockets "bundle" processor instead of a postprocessor

### DIFF
--- a/lib/autoprefixer-rails/sprockets.rb
+++ b/lib/autoprefixer-rails/sprockets.rb
@@ -22,7 +22,7 @@ module AutoprefixerRails
 
     # Register postprocessor in Sprockets depend on issues with other gems
     def install(assets)
-      assets.register_postprocessor('text/css', :autoprefixer) do |context, css|
+      assets.register_bundle_processor('text/css', :autoprefixer) do |context, css|
         process(context, css)
       end
     end


### PR DESCRIPTION
Hello!

By using `assets.register_bundle_processor`, we only run autoprefixer *after* sprockets concatenates its files into a "bundle". This can speed things up significantly, since each call to #process has to spin up a node.js process via ExecJS.

This doesn't seem to break the tests, but I'm not sure how much the tests cover this, and whether it'll be a breaking change or not.

Thoughts? 