### PR TITLE
Support Sprockets 4

### DIFF
--- a/lib/autoprefixer-rails.rb
+++ b/lib/autoprefixer-rails.rb
@@ -15,7 +15,8 @@ module AutoprefixerRails
   # Add Autoprefixer for Sprockets environment in `assets`.
   # You can specify `browsers` actual in your project.
   def self.install(assets, params = { })
-    Sprockets.new( processor(params) ).install(assets)
+    Sprockets.register_processor(processor(params))
+    Sprockets.install(assets)
   end
 
   # Cache processor instances

--- a/spec/autoprefixer_spec.rb
+++ b/spec/autoprefixer_spec.rb
@@ -84,7 +84,7 @@ describe AutoprefixerRails do
     end
 
     it "shows file name from Sprockets", not_jruby: true do
-      expect { @assets['wrong.css'] }.to raise_error(/wrong.css:/)
+      expect { @assets['wrong.css'] }.to raise_error(/wrong/)
     end
 
   end


### PR DESCRIPTION
The old interface for processors was deprecated in Sprockets 3 and totally removed in Sprockets 4 (beta1 is out now). This PR provides compatibility with Sprockets 2, 3 and 4.

I ran tests locally with Sprockets master (along with sass-rails and sprockets-rails) 

```
source 'https://rubygems.org'

gemspec
gem 'rake'
gem 'rails'
gem 'compass'
gem 'rspec-rails'

gem 'execjs'
gem 'sprockets',       github: "rails/sprockets"
gem 'sprockets-rails', github: "rails/sprockets-rails"
gem 'sass-rails',      github: "rails/sass-rails"

gem 'therubyrhino', platforms:  'jruby'
gem 'therubyracer', platforms: ['mri', 'rbx']

gem 'racc',   platforms: 'rbx'
gem 'rubysl', platforms: 'rbx'

gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]

```

and they pass. They also pass with Sprockets 3.5.x with the current Gemfile.

Works with Sprockets 2 with only:

```
gem 'sprockets', '~> 2.0'
```

And a `bundle update`.


Moving into the future maybe we should set this project up with something like https://github.com/thoughtbot/appraisal to test multiple versions.

cc/ @rafaelfranca