### PR TITLE
Remove json gem

### DIFF
--- a/autoprefixer-rails.gemspec
+++ b/autoprefixer-rails.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |s|
   s.license  = 'MIT'
 
   s.add_dependency 'execjs', '>= 0'
-  s.add_dependency 'json',   '>= 0'
 end


### PR DESCRIPTION
JSON support is in Ruby since 1.9 so there is no need to have json gem as a dependency.

Inspired by this Rack’s PR https://github.com/rack/rack/pull/1011