### PR TITLE
Source path isn't what we want here

### DIFF
--- a/lib/autoprefixer-rails/sprockets.rb
+++ b/lib/autoprefixer-rails/sprockets.rb
@@ -9,7 +9,7 @@ module AutoprefixerRails
 
     # Sprockets 3 and 4 API
     def self.call(input)
-      filename  = input[:source_path] || input[:filename]
+      filename  = input[:filename]
       source    = input[:data]
       run(filename, source)
     end

--- a/spec/app/app/controllers/css_controller.rb
+++ b/spec/app/app/controllers/css_controller.rb
@@ -1,6 +1,6 @@
 class CssController < ApplicationController
   def test
-    file = params[:file] + '.css'
+    file = params[:exact_file] || params[:file] + '.css'
     render plain: Rails.application.assets[file].to_s.gsub(/;(\s})/, '\1')
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -29,6 +29,16 @@ describe CssController, type: :controller do
       expect(clear_css).to eq 'a { -webkit-mask: none; mask: none }'
     end
   end
+
+  if sprockets_4?
+    it "works with sprockets 4 source maps" do
+      get :test, exact_file: "sass.css.map"
+      expect(response).to be_success
+
+      source_map = JSON.parse(response.body)
+      expect(source_map["sources"].first).to include("spec/app/app/assets/stylesheets/loaded.sass")
+    end
+  end
 end
 
 describe 'Rake task' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,7 @@ require 'rspec/rails'
 RSpec.configure do |c|
   c.filter_run_excluding not_jruby: RUBY_PLATFORM == 'java'
 end
+
+def sprockets_4?
+  Gem::Version.new(Sprockets::VERSION) > Gem::Version.new("4.0.x")
+end


### PR DESCRIPTION
Add a failing test for Sprockets 4 and fix

Previously sprockets 4 source maps were breaking but there was no test for them. This commit adds tests.

Reference https://github.com/rails/sprockets/pull/292#issuecomment-218786083

Fully addresses https://github.com/ai/autoprefixer-rails/pull/85#issuecomment-218786627