### PR TITLE
Adjust file retrieval for autoprefixer.js

### DIFF
--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -115,7 +115,7 @@ module AutoprefixerRails
 
     # Cache autoprefixer.js content
     def read_js
-      @@js ||= Pathname(__FILE__).join("../../../vendor/autoprefixer.js").read
+      @@js ||= Pathname(File.dirname(__FILE__)).join("../../vendor/autoprefixer.js").read
     end
 
     # Return processor JS with some extra methods


### PR DESCRIPTION
As outlined in #105: 

We've installed the gem and Rails boots up properly, but when compiling the CSS we get a runtime error:
```
Errno::ENOTDIR - Not a directory @ rb_sysopen - path-to-rvm-gem-directory/autoprefixer-rails-6.4.0.1/lib/autoprefixer-rails/processor.rb/../../../vendor/autoprefixer.js
  (in path-to-app/app/assets/stylesheets/project-chimp/main.scss):
  autoprefixer-rails (6.4.0.1) lib/autoprefixer-rails/processor.rb:118:in `read_js'
  autoprefixer-rails (6.4.0.1) lib/autoprefixer-rails/processor.rb:123:in `build_js'
  autoprefixer-rails (6.4.0.1) lib/autoprefixer-rails/processor.rb:112:in `runtime'
  autoprefixer-rails (6.4.0.1) lib/autoprefixer-rails/processor.rb:28:in `process'
  autoprefixer-rails (6.4.0.1) lib/autoprefixer-rails/sprockets.rb:20:in `run'
  autoprefixer-rails (6.4.0.1) lib/autoprefixer-rails/sprockets.rb:59:in `render'
  sprockets (2.11.0) lib/sprockets/context.rb:197:in `block in evaluate'
  sprockets (2.11.0) lib/sprockets/context.rb:194:in `evaluate'
```

I'm on rails 4.1.13 &  sprockets 2.11.0.

It's complaining about this line: https://github.com/ai/autoprefixer-rails/blob/master/lib/autoprefixer-rails/processor.rb#L118

I suspect it has to do with the fact that it's accessing `autoprefixer.js` via a relative path, and there's issues with that. At least on my machine, that relative path was off. It also seems to be calculating the relative path from the filename itself vs. the directory the `processor.rb` file is in.

I was able to get autoprefixer to play nicely when I changed the line in `processor.rb` to use `File.dirname` and remove one of the `.../` directory changes.

Please review this and let me know if this makes sense!