### PR TITLE
Support autoprefixer.yml's provided by engines

### DIFF
--- a/lib/autoprefixer-rails/railtie.rb
+++ b/lib/autoprefixer-rails/railtie.rb
@@ -5,29 +5,42 @@ begin
     class Railtie < ::Rails::Railtie
       rake_tasks do |app|
         require 'rake/autoprefixer_tasks'
-        Rake::AutoprefixerTasks.new( config(app.root) ) if defined? app.assets
+        Rake::AutoprefixerTasks.new( config ) if defined? app.assets
       end
 
       if config.respond_to?(:assets) and not config.assets.nil?
         config.assets.configure do |env|
-          AutoprefixerRails.install(env, config(env.root))
+          AutoprefixerRails.install(env, config)
         end
       else
         initializer :setup_autoprefixer, group: :all do |app|
           if defined? app.assets and not app.assets.nil?
-            AutoprefixerRails.install(app.assets, config(app.root))
+            AutoprefixerRails.install(app.assets, config)
           end
         end
       end
 
-      # Read browsers requirements from application config
-      def config(root)
-        file   = File.join(root, 'config/autoprefixer.yml')
-        params = ::YAML.load_file(file) if File.exist?(file)
-        params ||= {}
+      # Read browsers requirements from application or engine config
+      def config
+        params = {}
+
+        roots.each do |root|
+          file = File.join(root, 'config/autoprefixer.yml')
+
+          if File.exist?(file)
+            params = ::YAML.load_file(file)
+
+            break
+          end
+        end
+
         params = params.symbolize_keys
         params[:env] ||= Rails.env.to_s
         params
+      end
+
+      def roots
+        [Rails.application.root] + Rails::Engine.subclasses.map(&:root)
       end
     end
   end


### PR DESCRIPTION
This adds support for `autoprefixer.yml`s provided by engines as suggested in #118.  It uses the first config file it can find, starting with the host app, then looking at each engine.