### PR TITLE
Skip empty config/autoprefixer.yml

### DIFF
--- a/lib/autoprefixer-rails/railtie.rb
+++ b/lib/autoprefixer-rails/railtie.rb
@@ -28,7 +28,9 @@ begin
           file = File.join(root, 'config/autoprefixer.yml')
 
           if File.exist?(file)
-            params = ::YAML.load_file(file)
+            parsed = ::YAML.load_file(file)
+            next unless parsed
+            params = parsed
 
             break
           end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,0 +1,29 @@
+require_relative 'spec_helper'
+
+describe AutoprefixedRails::Railtie do
+  before do
+    @railtie = AutoprefixedRails::Railtie.instance
+  end
+
+  context 'with config/autoprefixer.yml' do
+    it 'works' do
+      expect(@railtie.config).to eq(cascade: false, supports: false, env: 'test')
+    end
+  end
+
+  context 'with empty config/autoprefixer.yml' do
+    before do
+      file_path = File.join(Rails.application.root, 'config/autoprefixer.yml')
+      allow(File).to receive(:exists?).with(file_path) { true }
+      allow(::YAML).to receive(:load_file).with(file_path) { false } # empty yaml
+    end
+
+    it 'skips empty yaml' do
+      expect { @railtie.config }.not_to raise_error
+    end
+
+    it 'works' do
+      expect(@railtie.config).to eq(env: 'test')
+    end
+  end
+end


### PR DESCRIPTION
fixes #123
Empty autoprefixer.yml breaks my rake task
https://github.com/ai/autoprefixer-rails/issues/123