### PR TITLE
Fix misnamed reference to `Runtimes` constant name

### DIFF
--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -146,7 +146,7 @@ module AutoprefixerRails
     def runtime
       @runtime ||= begin
         if ExecJS.eval('typeof Uint8Array') != 'function'
-          if ExecJS.runtime == ExecJS::Runtimes::RubyRacer
+          if ExecJS.runtime.name.start_with?('therubyracer')
             raise "ExecJS::RubyRacerRuntime is not supported. " +
                   "Please replace therubyracer with mini_racer " +
                   "in your Gemfile or use Node.js as ExecJS runtime."

--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -146,7 +146,7 @@ module AutoprefixerRails
     def runtime
       @runtime ||= begin
         if ExecJS.eval('typeof Uint8Array') != 'function'
-          if ExecJS.runtime == ExecJS::Runtimes::RubyRacerRuntime
+          if ExecJS.runtime == ExecJS::Runtimes::RubyRacer
             raise "ExecJS::RubyRacerRuntime is not supported. " +
                   "Please replace therubyracer with mini_racer " +
                   "in your Gemfile or use Node.js as ExecJS runtime."


### PR DESCRIPTION
Fixes #141. /cc @kwalrath @Sfshaza @filiph