### PR TITLE
Make explicit the MiniRacer environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ before_install:
   - nvm install node
 env:
   - EXECJS_RUNTIME=Node
-  # mini_racer
-  -
+  - EXECJS_RUNTIME=MiniRacer
 matrix:
   exclude:
     - rvm: "2.3"


### PR DESCRIPTION
Make explicit the runtime being used on travis test. Related to #146 .