### PR TITLE
Fix NameError when processing without Rails

### DIFF
--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -76,7 +76,7 @@ module AutoprefixerRails
     private
 
     def params_with_browsers(from = nil)
-      from ||= if defined? Rails&.respond_to?(:root) && Rails&.root
+      from ||= if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
         Rails.root.join("app/assets/stylesheets").to_s
       else
         "."

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -9,4 +9,17 @@ describe AutoprefixerRails::Processor do
       "test" => ["ios 8"],
     })
   end
+
+  context "without Rails" do
+    before do
+      hide_const("Rails")
+    end
+
+    it "doesn't raise error during processing" do
+      processor = AutoprefixerRails::Processor.new
+      expect {
+        processor.process("")
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This fixes a bug of `Rails` detection logic which introduced in #153 .

Without this fix, `NameError` will raise:
```
NameError: uninitialized constant AutoprefixerRails::Processor::Rails
/opt/build/cache/bundle/ruby/2.6.0/gems/autoprefixer-rails-9.4.10/lib/autoprefixer-rails/processor.rb:80:in `params_with_browsers'
/opt/build/cache/bundle/ruby/2.6.0/gems/autoprefixer-rails-9.4.10/lib/autoprefixer-rails/processor.rb:28:in `process'
```

Before (without Rails):
```ruby
$ irb
irb(main):001:0> defined? Rails&.respond_to?(:root) && Rails&.root
=> "expression"
```

After (without Rails):
```ruby
$ irb
irb(main):002:0> defined?(Rails) && Rails.respond_to?(:root) && Rails.root
=> nil
```
