### PR TITLE
Update sample with `grid: true` for `-ms-` prefix output for CSS Grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If you need to specify browsers for your Rails project, you can save them to
 
     ```yaml
     flexbox: no-2009
+    grid: true # required to enable `-ms-` prefix output for CSS Grids
     browsers:
       - "> 1%"
       - "last 2 versions"


### PR DESCRIPTION
This updates the config sample in the README so its clear how to enable the `-ms-` prefix for CSS Grids. This was brought up in #135 and fixed but not documented here. Related discussion in #149.