### PR TITLE
Updating the example to use .scss extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ rake tmp:clear
 
 Write your CSS (Sass, Stylus, LESS) rules without vendor prefixes
 and Autoprefixer will apply prefixes for you.
-For example in `app/assets/stylesheet/foobar.sass`:
+For example in `app/assets/stylesheet/foobar.scss`:
 
 ```sass
 :fullscreen a


### PR DESCRIPTION
It looks like .sass is deprecated [https://github.com/sass/ruby-sass]. Following this set-up, changing the extension from .sass to .scss seems to render properly now.