### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   NewCops: enable
   TargetRubyVersion: 2.4

--- a/autoprefixer-rails.gemspec
+++ b/autoprefixer-rails.gemspec
@@ -10,9 +10,8 @@ Gem::Specification.new do |s|
   s.summary     = "Parse CSS and add vendor prefixes to CSS rules using " \
     "values from the Can I Use website."
 
-  s.files = `git ls-files`.split("\n")
-  s.files.reject! { |i| i =~ /^\.|build.sh|Dockerfile|Gemfile/ }
-  s.test_files       = `git ls-files -- {spec}/*`.split("\n")
+  s.files = Dir["{lib,vendor}/**/*", "LICENSE", "CHANGELOG.md", "README.md"]
+  s.test_files       = Dir["spec/**/*"].reject { |f| File.directory?(f) }
   s.extra_rdoc_files = ["README.md", "LICENSE", "CHANGELOG.md"]
   s.require_path     = "lib"
   s.required_ruby_version = ">= 2.4"
@@ -30,7 +29,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "~> 0.85.1"
+  s.add_development_dependency "rubocop-packaging", "~> 0.1.1"
   s.add_development_dependency "standard"
 
   s.metadata["changelog_uri"] = "https://github.com/ai/autoprefixer-rails/blob/master/CHANGELOG.md"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 ENV["RAILS_ENV"] ||= "test"
 
 require_relative "app/config/environment"
-require_relative "../lib/autoprefixer-rails"
+require "autoprefixer-rails"
 
 require "rspec/rails"
 


### PR DESCRIPTION
Hi @ai,

This is the last one from my end, finally! :sweat_smile: 
It drops the usage of `git` in gemspec. Thereby helping us to maintain this more easily in Debian! :rocket: 

Really thanks for your support so far, you're the best! :heart: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>