### PR TITLE
Print deprecation warning only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 9.8.6.2
+* Print deprecation warning only once.
+
 ## 9.8.6.1
 * Improve deprecated warnings.
 

--- a/lib/autoprefixer-rails.rb
+++ b/lib/autoprefixer-rails.rb
@@ -32,6 +32,19 @@ module AutoprefixerRails
   def self.processor(params = {})
     Processor.new(params)
   end
+
+  def self.show_deprecation_message!
+    return unless defined?(ActiveSupport::Deprecation)
+
+    return if defined?(@deprecation_shown)
+
+    ActiveSupport::Deprecation.warn(
+      "autoprefixer-rails was deprected. Migration guide:\n" \
+      "https://github.com/ai/autoprefixer-rails/wiki/Deprecated"
+    )
+
+    @deprecation_shown = true
+  end
 end
 
 require_relative "autoprefixer-rails/result"

--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -20,12 +20,8 @@ module AutoprefixerRails
     # * `to` with output CSS file name.
     # * `map` with true to generate new source map or with previous map.
     def process(css, opts = {})
-      if defined?(ActiveSupport::Deprecation)
-        ActiveSupport::Deprecation.warn(
-          "autoprefixer-rails was deprected. Migration guide:\n" \
-          "https://github.com/ai/autoprefixer-rails/wiki/Deprecated"
-        )
-      end
+      AutoprefixerRails.show_deprecation_message!
+
       opts = convert_options(opts)
 
       apply_wrapper =


### PR DESCRIPTION
Printing deprecation for every `.process` call could produce a lot of noise in case autoprefixer-rails is used to process CSS without Assets Pipeline (e.g., to dynamically build CSS on-the-fly).