### PR TITLE
Remove deprecation warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+* Remove deprecation warnings.
+
 ## 9.8.6.3
 * Fix deprecation warning for non-Rails environment.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
      src="http://postcss.github.io/autoprefixer/logo.svg"
      title="Autoprefixer logo by Anton Lovchikov">
 
-**DEPRECATED. [Migration Guide.]**
-
 [Autoprefixer] is a tool to parse CSS and add vendor prefixes to CSS rules
 using values from the [Can I Use] database. This gem provides Ruby
 and Ruby on Rails integration with this JavaScript tool.
@@ -14,7 +12,6 @@ and Ruby on Rails integration with this JavaScript tool.
 <img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg" alt="Sponsored by Evil Martians" width="236" height="54">
 </a>
 
-[Migration Guide.]: https://github.com/ai/autoprefixer-rails/wiki/Deprecated
 [Autoprefixer]:     https://github.com/postcss/autoprefixer
 [Can I Use]:        http://caniuse.com/
 [PostCSS]:          https://postcss.org/

--- a/autoprefixer-rails.gemspec
+++ b/autoprefixer-rails.gemspec
@@ -21,9 +21,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/ai/autoprefixer-rails"
   s.license  = "MIT"
 
-  s.post_install_message = "autoprefixer-rails was deprected. Migration guide:\n" \
-    "https://github.com/ai/autoprefixer-rails/wiki/Deprecated"
-
   s.add_dependency "execjs", ">= 0"
 
   s.add_development_dependency "rails"

--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -7,19 +7,6 @@ require "json"
 IS_SECTION = /^\s*\[(.+)\]\s*$/.freeze
 
 module AutoprefixerRails
-  def self.show_deprecation_message!
-    return unless defined?(ActiveSupport::Deprecation)
-
-    return if defined?(@deprecation_shown)
-
-    ActiveSupport::Deprecation.warn(
-      "autoprefixer-rails was deprected. Migration guide:\n" \
-      "https://github.com/ai/autoprefixer-rails/wiki/Deprecated"
-    )
-
-    @deprecation_shown = true
-  end
-
   # Ruby to JS wrapper for Autoprefixer processor instance
   class Processor
     def initialize(params = {})
@@ -33,8 +20,6 @@ module AutoprefixerRails
     # * `to` with output CSS file name.
     # * `map` with true to generate new source map or with previous map.
     def process(css, opts = {})
-      AutoprefixerRails.show_deprecation_message!
-
       opts = convert_options(opts)
 
       plugin_opts = params_with_browsers(opts[:from]).merge(opts)


### PR DESCRIPTION
Discussion: #168

This PR removes deprecation warnings on the master branch.

Since master branch is based on development version of autoprefixer, should I also create a branch based on 9.8.6.3 ?

Sorry for the delay, I was traveling in the past few days.
