### PR TITLE
Bump minimal nodejs version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Windows users should install [Node.js]. Autoprefixer Rails doesn’t work with
 old JScript in Windows.
 
 Autoprefixer Rails uses [ExecJS] that will use the best available JavaScript
-runtime. Currently this gem is tested to work with Node.js version 6 and up and
-with [mini_racer], but will not work with [therubyracer].
+runtime. Currently this gem is tested to work with Node.js version 12 and up
+and with [mini_racer], but will not work with [therubyracer].
 
 [Node.js]: http://nodejs.org/
 [ExecJS]: https://github.com/rails/execjs


### PR DESCRIPTION
Since the 10.0.0 release, the minimal nodejs version as been bump to 12 according to this [comment](https://github.com/ai/autoprefixer-rails/issues/178#issuecomment-693096133)