### PR TITLE
fix node version check expression.

### DIFF
--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -135,7 +135,7 @@ module AutoprefixerRails
           major = version.match(/^v(\d+)/)[1].to_i
 
           # supports 10, 12, 14+
-          if major < 9 || [11, 13].include?(major)
+          unless [10, 12].include?(major) || major >= 14
             raise "Autoprefixer doesn’t support Node #{version}. Update it."
           end
         end


### PR DESCRIPTION
https://github.com/ai/autoprefixer-rails/commit/bb3a1d5fa2087a20e070c68c2295e5143eecc8c0#r42374899

Node 9 was allowed by accident.
Thanks @just1602 