### PR TITLE
Fix cannot find version of process

### DIFF
--- a/autoprefixer-rails.gemspec
+++ b/autoprefixer-rails.gemspec
@@ -20,9 +20,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/ai/autoprefixer-rails"
   s.license  = "MIT"
 
-  # see #203, `process` is undefined in 2.8
-  s.add_dependency "execjs", "< 2.8.0"
-
   s.add_development_dependency "rails"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails"

--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -9,7 +9,7 @@ IS_SECTION = /^\s*\[(.+)\]\s*$/.freeze
 module AutoprefixerRails
   # Ruby to JS wrapper for Autoprefixer processor instance
   class Processor
-    SUPPORTED_RUNTIMES = [ExecJS::Runtimes::Node, ExecJS::Runtimes::MiniRacer]
+    SUPPORTED_RUNTIMES = [ExecJS::Runtimes::Node, ExecJS::Runtimes::MiniRacer].freeze
 
     def initialize(params = {})
       @params = params || {}
@@ -131,7 +131,7 @@ module AutoprefixerRails
     def runtime
       @runtime ||= begin
         if ExecJS.runtime == ExecJS::Runtimes::Node
-          version = ExecJS.runtime.eval("process.version")
+          version = ExecJS.runtime.eval("this.process.version")
           major = version.match(/^v(\d+)/)[1].to_i
 
           # supports 10, 12, 14+
@@ -147,7 +147,7 @@ module AutoprefixerRails
         # Only complain about unsupported runtimes when it failed to parse our script.
         raise <<~MSG
           Your ExecJS runtime #{ExecJS.runtime.name} isn't supported by autoprefixer-rails,
-          please switch to #{SUPPORTED_RUNTIMES.map(&:name).join(' or ')}
+          please switch to #{SUPPORTED_RUNTIMES.map(&:name).join(" or ")}
         MSG
       end
     end


### PR DESCRIPTION
- The error occurs that is because execjs has been changed `process` to `this.process`.
- Fix #203
