### PR TITLE
Do not use open dependency version for `execjs`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "execjs"
+gem "execjs", "~> 2"
 gem "rails", ">= 5.0.0.beta2"
 gem "sassc-rails"
 gem "sprockets", ">= 4.0.0.beta1"

--- a/autoprefixer-rails.gemspec
+++ b/autoprefixer-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/ai/autoprefixer-rails"
   s.license  = "MIT"
 
-  s.add_dependency "execjs", "> 0"
+  s.add_dependency "execjs", "~> 2"
 
   s.add_development_dependency "rails"
   s.add_development_dependency "rake"


### PR DESCRIPTION
On `gem build autoprefixer-rails`
there is
```
WARNING:  open-ended dependency on execjs (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
```

I think it's better to use major version as required version, since
someone may install `autoprefixer-rails` with execjs v1 or even v0 which
may not work at all

Also there is a lot of development dependencies with open version,
but I don't touch them - it's up to maintainers to decide if this need
to be cchanged