### PR TITLE
RSpec: no monkey patching, support --only-failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/
 Gemfile.lock
 
 build/node_modules/
+.rspec_status

--- a/spec/autoprefixer_spec.rb
+++ b/spec/autoprefixer_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "spec_helper"
 
-describe AutoprefixerRails do
+RSpec.describe AutoprefixerRails do
   before :all do
     @dir = Pathname(__FILE__).dirname
     @css = @dir.join("app/app/assets/stylesheets/test.css").read

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "spec_helper"
 
-describe AutoprefixerRails::Processor do
+RSpec.describe AutoprefixerRails::Processor do
   it "parses config" do
     config    = "# Comment\n ie 11\n \nie 8 # sorry\n[test ]\nios 8"
     processor = AutoprefixerRails::Processor.new

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "spec_helper"
 
-describe CssController, type: :controller do
+RSpec.describe CssController, type: :controller do
   before :all do
     cache = Rails.root.join("tmp/cache")
     cache.rmtree if cache.exist?
@@ -33,7 +33,7 @@ describe CssController, type: :controller do
   end
 end
 
-describe "Rake task" do
+RSpec.describe "Rake task" do
   it "shows debug" do
     info = `cd spec/app; bundle exec rake autoprefixer:info`
     expect(info).to match(/Browsers:\n  Chrome: 25\n\n/)

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "spec_helper"
 
-describe AutoprefixedRails::Railtie do
+RSpec.describe AutoprefixedRails::Railtie do
   before do
     @railtie = AutoprefixedRails::Railtie.instance
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ warn "ExecJS runtime is #{ExecJS.runtime.class}"
 
 RSpec.configure do |c|
   c.filter_run_excluding not_jruby: RUBY_PLATFORM == "java"
+  c.example_status_persistence_file_path = ".rspec_status"
 end
 
 def sprockets_4?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ warn "ExecJS runtime is #{ExecJS.runtime.class}"
 
 RSpec.configure do |c|
   c.filter_run_excluding not_jruby: RUBY_PLATFORM == "java"
+  c.disable_monkey_patching!
   c.example_status_persistence_file_path = ".rspec_status"
 end
 


### PR DESCRIPTION
This PR is a maintenance change about RSpec.

- Disable the RSpec monkey-patches to `Object`, `Module`. [RSpec docs: Zero monkey-patching mode](https://relishapp.com/rspec/rspec-core/v/3-10/docs/configuration/zero-monkey-patching-mode)
- Save the RSpec test run state in a git-ignored `.rspec_status` file. [RSpec docs](https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures)