### PR TITLE
Linting: Update standard yml to ruby 24 syntax

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,1 @@
-ruby_version: 2.3
+ruby_version: 2.4

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task default: [:spec, "standard:fix"]
 task :clobber_package do
   begin
     rm_r "pkg"
-  rescue StandardError
+  rescue
     nil
   end
 end
@@ -26,10 +26,10 @@ desc "Test all Gemfiles from spec/*.gemfile"
 task :test_all do
   require "pty"
   require "shellwords"
-  cmd      = "bundle update && bundle exec rake --trace"
-  statuses = Dir.glob("./sprockets*.gemfile").map do |gemfile|
+  cmd = "bundle update && bundle exec rake --trace"
+  statuses = Dir.glob("./sprockets*.gemfile").map { |gemfile|
     Bundler.with_clean_env do
-      env = { "BUNDLE_GEMFILE" => gemfile }
+      env = {"BUNDLE_GEMFILE" => gemfile}
       warn "Testing #{File.basename(gemfile)}:"
       warn "  export BUNDLE_GEMFILE=#{gemfile}"
       warn "  #{cmd}"
@@ -44,7 +44,7 @@ task :test_all do
       end
       [$CHILD_STATUS&.exitstatus&.zero?, gemfile]
     end
-  end
+  }
   failed = statuses.reject(&:first).map(&:last)
   if failed.empty?
     warn "✓ Tests pass with all #{statuses.size} gemfiles"

--- a/autoprefixer-rails.gemspec
+++ b/autoprefixer-rails.gemspec
@@ -3,22 +3,22 @@
 require File.expand_path("lib/autoprefixer-rails/version", __dir__)
 
 Gem::Specification.new do |s|
-  s.platform    = Gem::Platform::RUBY
-  s.name        = "autoprefixer-rails"
-  s.version     = AutoprefixerRails::VERSION.dup
-  s.date        = Time.now.strftime("%Y-%m-%d")
-  s.summary     = "Parse CSS and add vendor prefixes to CSS rules using " \
+  s.platform = Gem::Platform::RUBY
+  s.name = "autoprefixer-rails"
+  s.version = AutoprefixerRails::VERSION.dup
+  s.date = Time.now.strftime("%Y-%m-%d")
+  s.summary = "Parse CSS and add vendor prefixes to CSS rules using " \
     "values from the Can I Use website."
 
   s.files = Dir["{lib,vendor}/**/*", "LICENSE", "CHANGELOG.md", "README.md"]
   s.extra_rdoc_files = ["README.md", "LICENSE", "CHANGELOG.md"]
-  s.require_path     = "lib"
+  s.require_path = "lib"
   s.required_ruby_version = ">= 2.4"
 
-  s.author   = "Andrey Sitnik"
-  s.email    = "andrey@sitnik.ru"
+  s.author = "Andrey Sitnik"
+  s.email = "andrey@sitnik.ru"
   s.homepage = "https://github.com/ai/autoprefixer-rails"
-  s.license  = "MIT"
+  s.license = "MIT"
 
   s.add_dependency "execjs", "~> 2"
 

--- a/lib/autoprefixer-rails.rb
+++ b/lib/autoprefixer-rails.rb
@@ -10,9 +10,9 @@ module AutoprefixerRails
     params = {}
     params[:overrideBrowserslist] = opts.delete(:overrideBrowserslist) if opts.key?(:overrideBrowserslist)
     params[:browsers] = opts.delete(:browsers) if opts.key?(:browsers)
-    params[:cascade]  = opts.delete(:cascade)  if opts.key?(:cascade)
-    params[:remove]   = opts.delete(:remove)   if opts.key?(:remove)
-    params[:env]      = opts.delete(:env)      if opts.key?(:env)
+    params[:cascade] = opts.delete(:cascade) if opts.key?(:cascade)
+    params[:remove] = opts.delete(:remove) if opts.key?(:remove)
+    params[:env] = opts.delete(:env) if opts.key?(:env)
     processor(params).process(css, opts)
   end
 

--- a/lib/autoprefixer-rails/result.rb
+++ b/lib/autoprefixer-rails/result.rb
@@ -14,8 +14,8 @@ module AutoprefixerRails
 
     def initialize(css, map, warnings)
       @warnings = warnings
-      @css      = css
-      @map      = map
+      @css = css
+      @map = map
     end
 
     # Stringify prefixed CSS

--- a/lib/autoprefixer-rails/sprockets.rb
+++ b/lib/autoprefixer-rails/sprockets.rb
@@ -12,7 +12,7 @@ module AutoprefixerRails
     # Sprockets 3 and 4 API
     def self.call(input)
       filename = input[:filename]
-      source   = input[:data]
+      source = input[:data]
       run(filename, source)
     end
 
@@ -32,10 +32,10 @@ module AutoprefixerRails
     def self.install(env)
       if ::Sprockets::VERSION.to_f < 4
         env.register_postprocessor("text/css",
-                                   ::AutoprefixerRails::Sprockets)
+          ::AutoprefixerRails::Sprockets)
       else
         env.register_bundle_processor("text/css",
-                                      ::AutoprefixerRails::Sprockets)
+          ::AutoprefixerRails::Sprockets)
       end
     end
 
@@ -43,17 +43,17 @@ module AutoprefixerRails
     def self.uninstall(env)
       if ::Sprockets::VERSION.to_f < 4
         env.unregister_postprocessor("text/css",
-                                     ::AutoprefixerRails::Sprockets)
+          ::AutoprefixerRails::Sprockets)
       else
         env.unregister_bundle_processor("text/css",
-                                        ::AutoprefixerRails::Sprockets)
+          ::AutoprefixerRails::Sprockets)
       end
     end
 
     # Sprockets 2 API new and render
     def initialize(filename)
       @filename = filename
-      @source   = yield
+      @source = yield
     end
 
     # Sprockets 2 API new and render

--- a/lib/rake/autoprefixer_tasks.rb
+++ b/lib/rake/autoprefixer_tasks.rb
@@ -13,7 +13,7 @@ module Rake
     attr_reader :browsers
 
     def initialize(params = {})
-      @params    = params
+      @params = params
       @processor = AutoprefixerRails.processor(@params)
       define
     end

--- a/spec/autoprefixer_spec.rb
+++ b/spec/autoprefixer_spec.rb
@@ -44,32 +44,32 @@ describe AutoprefixerRails do
   end
 
   it "generates separated source map" do
-    result = AutoprefixerRails.process(@css, map: { inline: false })
+    result = AutoprefixerRails.process(@css, map: {inline: false})
     expect(result.map).to be_a(String)
   end
 
   it "uses file name in syntax errors", not_jruby: true do
-    expect do
+    expect {
       AutoprefixerRails.process("a {", from: "a.css")
-    end.to raise_error(/a.css:/)
+    }.to raise_error(/a.css:/)
   end
 
   it "includes sourcesContent by default" do
-    map = AutoprefixerRails.process("a{}", map: { inline: false }).map
+    map = AutoprefixerRails.process("a{}", map: {inline: false}).map
     expect(map).to include("sourcesContent")
   end
 
   it "maps options from Ruby style" do
     map = AutoprefixerRails.process("a{}", map: {
-                                      sources_content: false,
-                                      inline: false
-                                    }).map
+      sources_content: false,
+      inline: false
+    }).map
 
     expect(map).not_to include("sourcesContent")
   end
 
   it "does not remove old prefixes on request" do
-    css    = "a { -moz-border-radius: 5px; border-radius: 5px }"
+    css = "a { -moz-border-radius: 5px; border-radius: 5px }"
     result = AutoprefixerRails.process(css, remove: false)
     expect(result.css).to eq(css)
   end
@@ -81,16 +81,16 @@ describe AutoprefixerRails do
   end
 
   it "returns warnings" do
-    css    = "a{background:linear-gradient(top,white,black)}"
+    css = "a{background:linear-gradient(top,white,black)}"
     result = AutoprefixerRails.process(css)
     expect(result.warnings).to eq(["<css input>:1:3: Gradient has outdated " \
       "direction syntax. New syntax is like `to left` instead of `right`."])
   end
 
   it "shows correct error on country statistics" do
-    expect do
+    expect {
       AutoprefixerRails.process("", overrideBrowserslist: "> 1% in US")
-    end.to raise_error(/Use Autoprefixer with webpack/)
+    }.to raise_error(/Use Autoprefixer with webpack/)
   end
 
   context "Sprockets" do

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -4,12 +4,12 @@ require_relative "spec_helper"
 
 describe AutoprefixerRails::Processor do
   it "parses config" do
-    config    = "# Comment\n ie 11\n \nie 8 # sorry\n[test ]\nios 8"
+    config = "# Comment\n ie 11\n \nie 8 # sorry\n[test ]\nios 8"
     processor = AutoprefixerRails::Processor.new
     expect(processor.parse_config(config)).to eql({
-                                                    "defaults" => ["ie 11", "ie 8"],
-                                                    "test" => ["ios 8"]
-                                                  })
+      "defaults" => ["ie 11", "ie 8"],
+      "test" => ["ios 8"]
+    })
   end
 
   context "without Rails" do
@@ -19,9 +19,9 @@ describe AutoprefixerRails::Processor do
 
     it "doesn't raise error during processing" do
       processor = AutoprefixerRails::Processor.new
-      expect do
+      expect {
         processor.process("")
-      end.not_to raise_error
+      }.not_to raise_error
     end
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -10,7 +10,7 @@ describe CssController, type: :controller do
 
   def test_file(file)
     if Rails.version.split(".").first.to_i >= 5
-      get :test, params: { file: file }
+      get :test, params: {file: file}
     else
       get :test, file: file
     end


### PR DESCRIPTION
This PR configures linting rules to match Ruby 2.4, and runs the linter with automatic fixes applied.

The reason: The gemspec states that this gem can only be used with Ruby 2.4+.