### PR TITLE
Rakefile: Drop unused Rake task test_all

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,35 +21,3 @@ end
 
 desc "Delete all generated files"
 task clobber: [:clobber_package]
-
-desc "Test all Gemfiles from spec/*.gemfile"
-task :test_all do
-  require "pty"
-  require "shellwords"
-  cmd      = "bundle update && bundle exec rake --trace"
-  statuses = Dir.glob("./sprockets*.gemfile").map do |gemfile|
-    Bundler.with_clean_env do
-      env = { "BUNDLE_GEMFILE" => gemfile }
-      warn "Testing #{File.basename(gemfile)}:"
-      warn "  export BUNDLE_GEMFILE=#{gemfile}"
-      warn "  #{cmd}"
-      PTY.spawn(env, cmd) do |r, _w, pid|
-        begin
-          r.each_line { |l| puts l }
-        rescue Errno::EIO
-          # Errno:EIO error means that the process has finished giving output.
-        ensure
-          ::Process.wait pid
-        end
-      end
-      [$CHILD_STATUS&.exitstatus&.zero?, gemfile]
-    end
-  end
-  failed = statuses.reject(&:first).map(&:last)
-  if failed.empty?
-    warn "✓ Tests pass with all #{statuses.size} gemfiles"
-  else
-    warn "❌ FAILING #{failed * "\n"}"
-    exit 1
-  end
-end


### PR DESCRIPTION
This now-unused method was about "testing against many versions of Sprockets", which is nowadays not done.