### PR TITLE
Ensure sprockets-rails is loaded before autoprefixer-rails

### DIFF
--- a/lib/autoprefixer-rails/railtie.rb
+++ b/lib/autoprefixer-rails/railtie.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require "yaml"
+begin
+  require "sprockets/railtie"
+rescue LoadError
+end
 
 begin
   module AutoprefixedRails


### PR DESCRIPTION
Rails 7 no longer depends on sprockets-rails and thus no longer loads it early in the Rails boot process. The sprockets railtie must be loaded before the autoprefixer railtie otherwise autoprefixer fails to activate properly.

The problem only shows up when the Gemfile loads autoprefixer-rails before sprockets-rails. With this PR, it works either way.

Fixes #215 
