### PR TITLE
Move `IS_SECTION` out of toplevel namespace

### DIFF
--- a/lib/autoprefixer-rails/processor.rb
+++ b/lib/autoprefixer-rails/processor.rb
@@ -4,9 +4,9 @@ require "pathname"
 require "execjs"
 require "json"
 
-IS_SECTION = /^\s*\[(.+)\]\s*$/.freeze
-
 module AutoprefixerRails
+  IS_SECTION = /^\s*\[(.+)\]\s*$/.freeze
+
   # Ruby to JS wrapper for Autoprefixer processor instance
   class Processor
     SUPPORTED_RUNTIMES = [ExecJS::Runtimes::Node, ExecJS::Runtimes::MiniRacer]


### PR DESCRIPTION
I noticed this was at the toplevel of our application, and traced it back here. I don't think this needs to be at the toplevel, so I moved it under `AutoprefixerRails`.