### PR TITLE
Update documentation on source maps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Autoprefixer will generate a source map if you set `map` option to `true` in
 `process` method.
 
 You must set input and output CSS files paths (by `from` and `to` options)
-to generate correct map.
+to generate a correct map.
 
 ```ruby
 result = AutoprefixerRails.process(css,
@@ -212,11 +212,12 @@ result = AutoprefixerRails.process(css,
 ```
 
 Autoprefixer can also modify previous source map (for example, from Sass
-compilation). Just set original source map content (as string) to `map` option:
+compilation). Just set original source map content (as string) as `prev`
+in the `map` option.
 
 ```ruby
 result = AutoprefixerRails.process(css, {
-    map:   File.read('main.sass.css.map'),
+    map:   { prev: File.read('main.sass.css.map') },
     from: 'main.sass.css',
     to:   'main.min.css')
 


### PR DESCRIPTION
PostCSS only supports passing an existing source map as `{ map: { prev: "..." } }`, not directly as `{ map: "..." }`.
(As documented by https://github.com/postcss/postcss/blob/8.0.3/lib/postcss.d.ts#L235).

This is only a small change to the docs, but I have spent nearly a day looking for an error in my code until I decided to dig through the [autoprefixer-rails](https://github.com/ai/autoprefixer-rails), [autoprefixer](https://github.com/postcss/autoprefixer) and [PostCSS](https://github.com/postcss/postcss) source code to verify my suspicions.

Also, the heading that the [PostCSS API Docs](https://github.com/postcss/postcss#source-map-1) link should lead to has seemingly been removed in the meantime, but I wasn't sure what the correct target should be.