### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/autoprefixer-rails.gemspec
+++ b/autoprefixer-rails.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.metadata["changelog_uri"] = "https://github.com/ai/autoprefixer-rails/blob/master/CHANGELOG.md"
   s.metadata["source_code_uri"] = "https://github.com/ai/autoprefixer-rails"
   s.metadata["bug_tracker_uri"] = "https://github.com/ai/autoprefixer-rails/issues"
+  s.metadata["funding_uri"]     = "https://github.com/sponsors/ai"
 end


### PR DESCRIPTION
Added your github sponsors link to `funding_uri` to the gemspec to help increase visibility using the `bundle fund` command in Bundler.